### PR TITLE
1.1.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,13 @@ Allows users to use the damage tray for selected tokens that they own, and for t
 ## API
 - ```js
   effectiv.applyEffect(effect, targets, data = {effectData: null, concentration: null, caster: null})
-  ``` A helper function to allow users to apply effects.
+  ``` 
+  A helper function to allow users to apply effects.
 - ````js 
   effectiv.applyDamage(damage=[], opts={}, id)
-  ``` A helper function to allow users to apply damage.
+  ```
+  
+A helper function to allow users to apply damage.
 See scripts/api.mjs for more information. These helpers are mostly untested and being included before documentation is complete.
 ___
 ###### **Technical Details**

--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ Allows users to use the damage tray for selected tokens that they own, and for t
       caster: null 
     }
   )
-
+```
+```js
   /* in use...*/
   effectiv.applyEffect(
     effect, 
@@ -75,6 +76,8 @@ Allows users to use the damage tray for selected tokens that they own, and for t
    * @param {string} id    Uuid of the target.
    */
   async function applyDamage(damage=[], opts={}, id)
+```
+```js  
 
   /* in use...*/
   effectiv.applyDamage(damage=[], opts={}, id)

--- a/README.md
+++ b/README.md
@@ -29,22 +29,14 @@ This helper also allows the use of the other things the effects tray does, prima
 
 ```js
 /**
- * Helper function to allow for macros or other applications to apply 
- * effects to owned and unowned targets.
- * @param {string|object|ActiveEffect5e} effect The effect to apply.
- * @param {Set<Token5e>|Token5e[]|string[]|string} targets 
- * Targeted tokens.
+ * Helper function to allow for macros or other applications to apply effects to owned and unowned targets.
+ * @param {string|object|ActiveEffect5e} effect            The effect to apply.
+ * @param {Set<Token5e>|Token5e[]|string[]|string} targets Targeted tokens.
  * @param {object} [options]
- * @param {object} [options.effectData] A generic data object, which typically 
- *                            handles the level the originating spell 
- *                            was cast at, 
- *                            if it originated from a spell, if any. 
- *                            Use flags like { "flags.dnd5e.spellLevel": 1 }.
- * @param {string} [options.concentration] The ID (not Uuid) of the concentration 
- *                               effect this effect is dependent on, if any.
- * @param {string|Actor5e} [options.caster] The Uuid or Actor5e document of the actor 
- *                                that cast the spell that requires 
- *                                concentration, if any.
+ * @param {object} [options.effectData]                    A generic data object, which typically handles the level the originating spell was cast at, 
+ *                                                         if it originated from a spell, if any. Use flags like { "flags.dnd5e.spellLevel": 1 }.
+ * @param {string} [options.concentration]                 The ID (not Uuid) of the concentration effect this effect is dependent on, if any.
+ * @param {string|Actor5e} [options.caster]                The Uuid or Actor5e document of the actor that cast the spell that requires concentration, if any.
  */
 async function applyEffect(
   effect, 
@@ -68,12 +60,10 @@ effectiv.applyEffect(
 `applyDamage`, helper function to allow users to apply damage. This function has been tested not at all and is included as a courtesy. Personally I find the way damage information must be structured to respect resistances, etc is too much of a mess to test this even a single time, but if someone really wants to do this over a socket but didn't write their own socket handler for it...here you go. Full, extensive documentation of the array that must be created is in scripts/api.mjs, copied directly from `dnd5e`, with the exception that socket transmission requires the sets to be arrays. Unlike `applyEffect`, this applies no damage via the requesting client, and so is basically only meant for damaging unowned targets. Users wishing to apply damage to owned targets should simply use the system's `Actor#applyDamage`.
 ```js
 /**
- * ... Much documentation cut here...see scripts/api.mjs or better yet, dnd5e...
- * Helper function to allow for macros or other applications to apply damage 
- * via socket request.
+ * Helper function to allow for macros or other applications to apply damage via socket request.
  * @param {array} damage Array of damage objects; see above.
- * @param {array} opts   Object of options (which may inlude arrays); see above.
- * @param {string} id    Uuid of the target.
+ * @param {array} opts Object of options (which may inlude arrays); see above.
+ * @param {string} id Uuid of the target.
  */
 async function applyDamage(damage=[], opts={}, id)
 ```
@@ -87,8 +77,7 @@ effectiv.applyDamage(damage=[], opts={}, id)
 /**
  * Sort tokens into owned and unowned categories.
  * @param {set|array} targets The set or array of tokens to be sorted.
- * @returns {Array}    An Array of length two whose elements are the 
- * partitioned pieces of the original
+ * @returns {Array}           An Array of length two, the elements of which are the partitioned pieces of the original.
  */
 function partitionTargets(targets)
 ```
@@ -106,17 +95,14 @@ These hooks have not been extensively tested.
  * Hook called before the effect is completed and applied.
  * @param {Actor5e} actor                The actor to create the effect on.
  * @param {ActiveEffect5e} effect        The effect to create.
- * @param {object} effectData            A generic data object that contains spellLevel in a 
- *                                       `dnd5e` scoped flag, and whatever else.
- * @param {ActiveEffect5e} concentration The concentration effect on which `effect` 
- *                                       is dependent, if it requires concentration.
+ * @param {object} effectData            A generic data object that contains spellLevel in a `dnd5e` scoped flag, and whatever else.
+ * @param {ActiveEffect5e} concentration The concentration effect on which `effect` is dependent, if it requires concentration.
  */
 Hooks.call("effectiv.preApplyEffect", actor, effect, { effectData, concentration });
 ```
 ```js
 /**
- * Hook called before the effect is completed and applied.
- * Same as abvove except for effectData
+ * Hook called before the effect is completed and applied. Same as abvove except for effectData
  * @param {object} effectData The packaged effect immediately before application.
  */
 Hooks.callAll("effectiv.applyEffect", actor, effect, { effectData, concentration });

--- a/README.md
+++ b/README.md
@@ -28,80 +28,79 @@ Now includes three helper functions exposed in the global scope under `effectiv`
 This helper also allows the use of the other things the effects tray does, primarily flagging effects with spellLevel, or any other arbitrary flags (via effectData), and making an effect dependent on a concentration effect (so it will be deleted when the concentration effect is). If concentration is used, because it passed as an ID, you must also pass the Uuid or Actor document of the actor the concentration effect is on.
 
 ```js
-  /**
-   * Helper function to allow for macros or other applications to apply effects to owned 
-   * and unowned targets.
-   * @param {string|object|ActiveEffect} effect The effect to apply. 
-   *                                            Can handle Uuid, effect data as an object, 
-   *                                            or an ActiveEffect proper.
-   * @param {set|array|string} targets          Targeted tokens. 
-   *                                            Handles `game.user.targets`, 
-   *                                            or any generic array of token placeables.
-   * @param {number|void} effectData            A generic data object, which typically handles
-   *                                            the level the originating spell was cast at, 
-   *                                            if it originated from a spell, if any. 
-   *                                            Use flags like { "flags.dnd5e.spellLevel": 1 }.
-   * @param {string|void} concentration         The ID (not Uuid) of the concentration 
-   *                                            effect this effect is dependent on, 
-   *                                            if any.
-   * @param {string|Actor5e|void} caster        The Uuid or Actor5e document of the actor 
-   *                                            that cast the spell that requires 
-   *                                            concentration, if any.
-   */
-  async function applyEffect(
-    effect, 
-    targets, 
-    data = { 
-      effectData: null, 
-      concentration: null, 
-      caster: null 
-    }
-  )
+/**
+ * Helper function to allow for macros or other applications to apply effects to owned 
+ * and unowned targets.
+ * @param {string|object|ActiveEffect} effect The effect to apply. 
+ *                                            Can handle Uuid, effect data as an object, 
+ *                                            or an ActiveEffect proper.
+ * @param {set|array|string} targets          Targeted tokens. 
+ *                                            Handles `game.user.targets`, 
+ *                                            or any generic array of token placeables.
+ * @param {number|void} effectData            A generic data object, which typically handles
+ *                                            the level the originating spell was cast at, 
+ *                                            if it originated from a spell, if any. 
+ *                                            Use flags like { "flags.dnd5e.spellLevel": 1 }.
+ * @param {string|void} concentration         The ID (not Uuid) of the concentration 
+ *                                            effect this effect is dependent on, 
+ *                                            if any.
+ * @param {string|Actor5e|void} caster        The Uuid or Actor5e document of the actor 
+ *                                            that cast the spell that requires 
+ *                                            concentration, if any.
+ */
+async function applyEffect(
+  effect, 
+  targets, 
+  data = { 
+    effectData: null, 
+    concentration: null, 
+    caster: null 
+  }
+)
 ```
 ```js
-  /* in use...*/
-  effectiv.applyEffect(
-    effect, 
-    targets, 
-    data = { 
-      effectData: null, 
-      concentration: null, 
-      caster: null 
-    }
-  )
+/* in use...*/
+effectiv.applyEffect(
+  effect, 
+  targets, 
+  data = { 
+    effectData: null, 
+    concentration: null, 
+    caster: null 
+  }
+)
 ```
 
 `applyDamage`, helper function to allow users to apply damage. This function has been tested not at all and is included as a courtesy. Personally I find the way damage information must be structured to respect resistances, etc is too much of a mess to test this even a single time, but if someone really wants to do this over a socket but didn't write their own socket handler for it...here you go. Full, extensive documentation of the array that must be created is in scripts/api.mjs, copied directly from `dnd5e`, with the exception that socket transmission requires the sets to be arrays. Unlike `applyEffect`, this applies no damage via the requesting client, and so is basically only meant for damaging unowned targets. Users wishing to apply damage to owned targets should simply use the system's `Actor#applyDamage`.
 ```js
-  /**
-   * ... Much documentation cut here...see scripts/api.mjs or better yet, dnd5e...
-   * Helper function to allow for macros or other applications to apply damage 
-   * via socket request.
-   * @param {array} damage Array of damage objects; see above.
-   * @param {array} opts   Object of options (which may inlude arrays); see above.
-   * @param {string} id    Uuid of the target.
-   */
-  async function applyDamage(damage=[], opts={}, id)
+/**
+ * ... Much documentation cut here...see scripts/api.mjs or better yet, dnd5e...
+ * Helper function to allow for macros or other applications to apply damage 
+ * via socket request.
+ * @param {array} damage Array of damage objects; see above.
+ * @param {array} opts   Object of options (which may inlude arrays); see above.
+ * @param {string} id    Uuid of the target.
+ */
+async function applyDamage(damage=[], opts={}, id)
 ```
 ```js  
-
-  /* in use...*/
-  effectiv.applyDamage(damage=[], opts={}, id)
+/* in use...*/
+effectiv.applyDamage(damage=[], opts={}, id)
 ```
 
 `partitionTargets`, a function similar to foundry's `Array#partition` but specifically designed to handle `game.user.targets`, a set, or an array of tokens. It sorts them into two arrays, the first array containing tokens that the user owns, and the second array containing those token's `document.uuid`s. This can be useful for determining what information needs to be sent over sockets. I have no idea why anyone would use this function, but here it is.
 ```js
-  /**
-   * Sort tokens into owned and unowned categories.
-   * @param {set|array} targets The set or array of tokens to be sorted.
-   * @returns {Array}    An Array of length two whose elements are the 
-   * partitioned pieces of the original
-   */
-  function partitionTargets(targets)
+/**
+ * Sort tokens into owned and unowned categories.
+ * @param {set|array} targets The set or array of tokens to be sorted.
+ * @returns {Array}    An Array of length two whose elements are the 
+ * partitioned pieces of the original
+ */
+function partitionTargets(targets)
 ```
 ```js
-  /* in use...*/
-  effectiv.partitionTargets(targets)
+/* in use...*/
+effectiv.partitionTargets(targets)
 ```
 
 ## Hooks
@@ -109,23 +108,24 @@ Now includes two hooks, `effectiv.preApplyEffect` and `effectiv.applyEffect`. Th
 
 These hooks have not been extensively tested.
 ```js
-  /**
-   * Hook called before the effect is completed and applied.
-   * @param {Actor5e} actor                The actor to create the effect on.
-   * @param {ActiveEffect5e} effect        The effect to create.
-   * @param {object} effectData            A generic data object that contains spellLevel in a 
-   *                                       `dnd5e` scoped flag, and whatever else.
-   * @param {ActiveEffect5e} concentration The concentration effect on which `effect` 
-   *                                       is dependent, if it requires concentration.
-   */
-  Hooks.call("effectiv.preApplyEffect", actor, effect, { effectData, concentration });
-
-  /**
-   * Hook called before the effect is completed and applied.
-   * Same as abvove except for effectData
-   * @param {object} effectData The packaged effect immediately before application.
-   */
-  Hooks.callAll("effectiv.applyEffect", actor, effect, { effectData, concentration });
+/**
+ * Hook called before the effect is completed and applied.
+ * @param {Actor5e} actor                The actor to create the effect on.
+ * @param {ActiveEffect5e} effect        The effect to create.
+ * @param {object} effectData            A generic data object that contains spellLevel in a 
+ *                                       `dnd5e` scoped flag, and whatever else.
+ * @param {ActiveEffect5e} concentration The concentration effect on which `effect` 
+ *                                       is dependent, if it requires concentration.
+ */
+Hooks.call("effectiv.preApplyEffect", actor, effect, { effectData, concentration });
+```
+```js
+/**
+ * Hook called before the effect is completed and applied.
+ * Same as abvove except for effectData
+ * @param {object} effectData The packaged effect immediately before application.
+ */
+Hooks.callAll("effectiv.applyEffect", actor, effect, { effectData, concentration });
 ```
 ___
 ###### **Technical Details**

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Allows users to use the damage tray for selected tokens that they own, and for t
 ## API
 - `effectiv.applyEffect(effect, targets, data = {effectData: null, concentration: null, caster: null})` A helper function to allow users to apply effects.
 - `effectiv.applyDamage(damage=[], opts={}, id)` A helper function to allow users to apply damage.
-See scripts\API.mjs for more information. These helpers are mostly untested and being included before documentation is complete.
+See scripts/API.mjs for more information. These helpers are mostly untested and being included before documentation is complete.
 ___
 ###### **Technical Details**
 

--- a/README.md
+++ b/README.md
@@ -91,13 +91,13 @@ This helper also allows the use of the other things the effects tray does, prima
 
 `partitionTargets`, a function similar to foundry's `Array#partition` but specifically designed to handle `game.user.targets`, a set, or an array of tokens. It sorts them into two arrays, the first array containing tokens that the user owns, and the second array containing those token's `document.uuid`s. This can be useful for determining what information needs to be sent over sockets. I have no idea why anyone would use this function, but here it is.
 ```js
-/**
- * Sort tokens into owned and unowned categories.
- * @param {set|array} targets The set or array of tokens to be sorted.
- * @returns {Array}    An Array of length two whose elements are the 
- * partitioned pieces of the original
- */
-function partitionTargets(targets)
+  /**
+   * Sort tokens into owned and unowned categories.
+   * @param {set|array} targets The set or array of tokens to be sorted.
+   * @returns {Array}    An Array of length two whose elements are the 
+   * partitioned pieces of the original
+   */
+  function partitionTargets(targets)
 ```
 ```js
   /* in use...*/
@@ -109,23 +109,23 @@ Now includes two hooks, `effectiv.preApplyEffect` and `effectiv.applyEffect`. Th
 
 These hooks have not been extensively tested.
 ```js
-/**
- * Hook called before the effect is completed and applied.
- * @param {Actor5e} actor                The actor to create the effect on.
- * @param {ActiveEffect5e} effect        The effect to create.
- * @param {object} effectData            A generic data object that contains spellLevel in a 
- *                                       `dnd5e` scoped flag, and whatever else.
- * @param {ActiveEffect5e} concentration The concentration effect on which `effect` 
- *                                       is dependent, if it requires concentration.
- */
- Hooks.call("effectiv.preApplyEffect", actor, effect, { effectData, concentration });
+  /**
+   * Hook called before the effect is completed and applied.
+   * @param {Actor5e} actor                The actor to create the effect on.
+   * @param {ActiveEffect5e} effect        The effect to create.
+   * @param {object} effectData            A generic data object that contains spellLevel in a 
+   *                                       `dnd5e` scoped flag, and whatever else.
+   * @param {ActiveEffect5e} concentration The concentration effect on which `effect` 
+   *                                       is dependent, if it requires concentration.
+   */
+  Hooks.call("effectiv.preApplyEffect", actor, effect, { effectData, concentration });
 
-/**
- * Hook called before the effect is completed and applied.
- * Same as abvove except for effectData
- * @param {object} effectData The packaged effect immediately before application.
- */
- Hooks.callAll("effectiv.applyEffect", actor, effect, { effectData, concentration });
+  /**
+   * Hook called before the effect is completed and applied.
+   * Same as abvove except for effectData
+   * @param {object} effectData The packaged effect immediately before application.
+   */
+  Hooks.callAll("effectiv.applyEffect", actor, effect, { effectData, concentration });
 ```
 ___
 ###### **Technical Details**

--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ Allows users to use the damage tray for selected tokens that they own, and for t
    *                                            that cast the spell that requires concentration, 
    *                                            if any.
    */
+  async function applyEffect(
+    effect, 
+    targets, 
+    data = { 
+      effectData: null, 
+      concentration: null, 
+      caster: null 
+    }
+  )
+
+  /* in use...*/
   effectiv.applyEffect(
     effect, 
     targets, 
@@ -63,6 +74,9 @@ Allows users to use the damage tray for selected tokens that they own, and for t
    * @param {array} opts   Object of options (which may inlude arrays); see above.
    * @param {string} id    Uuid of the target.
    */
+  async function applyDamage(damage=[], opts={}, id)
+
+  /* in use...*/
   effectiv.applyDamage(damage=[], opts={}, id)
 ```
 A helper function to allow users to apply damage.

--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ effectiv.applyEffect(
 /**
  * Helper function to allow for macros or other applications to apply damage via socket request.
  * @param {array} damage Array of damage objects; see above.
- * @param {array} opts Object of options (which may inlude arrays); see above.
- * @param {string} id Uuid of the target.
+ * @param {array} opts   Object of options (which may inlude arrays); see above.
+ * @param {string} id    Uuid of the target.
  */
 async function applyDamage(damage=[], opts={}, id)
 ```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Allows users to use the damage tray for selected tokens that they own, and for t
 ## API
 - `effectiv.applyEffect(effect, targets, data = {effectData: null, concentration: null, caster: null})` A helper function to allow users to apply effects.
 - `effectiv.applyDamage(damage=[], opts={}, id)` A helper function to allow users to apply damage.
-See scripts/API.mjs for more information. These helpers are mostly untested and being included before documentation is complete.
+See scripts/api.mjs for more information. These helpers are mostly untested and being included before documentation is complete.
 ___
 ###### **Technical Details**
 

--- a/README.md
+++ b/README.md
@@ -49,11 +49,9 @@ async function applyEffect(
 effectiv.applyEffect(
   effect, 
   targets, 
-  data = { 
-    effectData: null, 
-    concentration: null, 
-    caster: null 
-  }
+  effect, 
+  targets, 
+  { effectData: null, concentration: null, caster: null } = {}
 )
 ```
 
@@ -65,11 +63,11 @@ effectiv.applyEffect(
  * @param {array} opts   Object of options (which may inlude arrays); see above.
  * @param {string} id    Uuid of the target.
  */
-async function applyDamage(damage=[], opts={}, id)
+async function applyDamage(damage = [], opts = {}, id)
 ```
 ```js  
 /* in use...*/
-effectiv.applyDamage(damage=[], opts={}, id)
+effectiv.applyDamage(damage = [], opts = {}, id)
 ```
 
 `partitionTargets`, a function similar to foundry's `Array#partition` but specifically designed to handle `game.user.targets`, a set, or an array of tokens. It sorts them into two arrays, the first array containing tokens that the user owns, and the second array containing those token's `document.uuid`s. This can be useful for determining what information needs to be sent over sockets. I have no idea why anyone would use this function, but here it is.

--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ Allows users to use the damage tray for selected tokens that they own, and for t
 - **Multiple Effects with Concentration**: Allow multiple effects to be applied from spells with concentration (off by default).
 
 ## API
-- ```js
+```js
   effectiv.applyEffect(effect, targets, data = {effectData: null, concentration: null, caster: null})
-  ``` 
-  A helper function to allow users to apply effects.
-- ````js 
+```
+ A helper function to allow users to apply effects.
+
+```js 
   effectiv.applyDamage(damage=[], opts={}, id)
-  ```
-  
+```
 A helper function to allow users to apply damage.
 See scripts/api.mjs for more information. These helpers are mostly untested and being included before documentation is complete.
 ___

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Allows users to use the damage tray for selected tokens that they own, and for t
 - **Multiple Effects with Concentration**: Allow multiple effects to be applied from spells with concentration (off by default).
 
 ## API
-Now includes two helper functions exposed in the global scope under `effectiv`, `effectiv.applyEffect` and `effectiv.applyDamage`. These functions *have not been heavily tested* and are included now in the hopes that, if someone wants to use them, they will also test them for issues.
+Now includes three helper functions exposed in the global scope under `effectiv`, `effectiv.applyEffect`, `effectiv.applyDamage` and `effective.partitionTargets`. These functions *have not been heavily tested* and are included now in the hopes that, if someone wants to use them, they will also test them for issues.
 
 `applyEffect`, a helper function to allow users to apply effects. It allows users to apply effects via macro (or other module), and can take a variety of types of data when doing so, allowing effect data to be passed as the full ActiveEffect document, an effect Uuid, or an object (note that passing it as an object will not interact with refreshing duration or deleting effects of same origin, as determined by module setting, because creating an effect from an object will have its own unique origin). Similarly, this function allows target data to be passed as an array of Uuids, a single Uuid, an array of Tokens, or a Set, as `game.user.targets`.
 
@@ -70,6 +70,7 @@ This helper also allows the use of the other things the effects tray does, prima
     }
   )
 ```
+
 `applyDamage`, helper function to allow users to apply damage. This function has been tested not at all and is included as a courtesy. Personally I find the way damage information must be structured to respect resistances, etc is too much of a mess to test this even a single time, but if someone really wants to do this over a socket but didn't write their own socket handler for it...here you go. Full, extensive documentation of the array that must be created is in scripts/api.mjs, copied directly from `dnd5e`, with the exception that socket transmission requires the sets to be arrays. Unlike `applyEffect`, this applies no damage via the requesting client, and so is basically only meant for damaging unowned targets. Users wishing to apply damage to owned targets should simply use the system's `Actor#applyDamage`.
 ```js
   /**
@@ -87,6 +88,21 @@ This helper also allows the use of the other things the effects tray does, prima
   /* in use...*/
   effectiv.applyDamage(damage=[], opts={}, id)
 ```
+
+`partitionTargets`, a function similar to foundry's `Array#partition` but specifically designed to handle `game.user.targets`, a set, or an array of tokens. It sorts them into two arrays, the first array containing tokens that the user owns, and the second array containing those token's `document.uuid`s. This can be useful for determining what information needs to be sent over sockets. I have no idea why anyone would use this function, but here it is.
+```js
+/**
+ * Sort tokens into owned and unowned categories.
+ * @param {set|array} targets The set or array of tokens to be sorted.
+ * @returns {Array}    An Array of length two whose elements are the 
+ * partitioned pieces of the original
+ */
+function partitionTargets(targets)
+```
+```js
+  /* in use...*/
+  effective.partitionTargets(targets)
+```  
 See scripts/api.mjs for more information. These helpers are mostly untested and being included before documentation is complete.
 ___
 ###### **Technical Details**

--- a/README.md
+++ b/README.md
@@ -20,6 +20,28 @@ Allows users to use the damage tray for selected tokens that they own, and for t
 - **Remove 'Apply Effect to Actor'**: On the time of creation (i.e. drag & drop), remove 'Apply Effect to Actor' from effects on items that have a duration to allow for normal use of the timer (on by default).
 - **Multiple Effects with Concentration**: Allow multiple effects to be applied from spells with concentration (off by default).
 
+## Hooks
+Now includes two hooks, `effectiv.preApplyEffect` and `effectiv.applyEffect`. The former allows the data to be modified and explicitly returning `false` will prevent the effect from being applied. The later passes the same (modified in the case of effectData), information in its final state upon application.
+```js
+/**
+ * Hook called before the effect is completed and applied.
+ * @param {Actor5e} actor                The actor to create the effect on.
+ * @param {ActiveEffect5e} effect        The effect to create.
+ * @param {object} effectData            A generic data object that contains spellLevel in a 
+ *                                       `dnd5e` scoped flag, and whatever else.
+ * @param {ActiveEffect5e} concentration The concentration effect on which `effect` 
+ *                                       is dependent, if it requires concentration.
+ */
+ Hooks.call("effectiv.preApplyEffect", actor, effect, { effectData, concentration });
+
+/**
+ * Hook called before the effect is completed and applied.
+ * Same as abvove except for effectData
+ * @param {object} effectData The packaged effect immediately before application.
+ */
+ Hooks.callAll("effectiv.applyEffect", actor, effect, { effectData, concentration });
+```
+
 ## API
 Now includes three helper functions exposed in the global scope under `effectiv`, `effectiv.applyEffect`, `effectiv.applyDamage` and `effective.partitionTargets`. These functions *have not been heavily tested* and are included now in the hopes that, if someone wants to use them, they will also test them for issues.
 

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ effectiv.applyDamage(damage = [], opts = {}, id)
 ```js
 /**
  * Sort tokens into owned and unowned categories.
- * @param {set|array} targets The set or array of tokens to be sorted.
- * @returns {Array}           An Array of length two, the elements of which are the partitioned pieces of the original.
+ * @param {Set|array} targets The set or array of tokens to be sorted.
+ * @returns {array}           An Array of length two, the elements of which are the partitioned pieces of the original.
  */
 function partitionTargets(targets)
 ```

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ This helper also allows the use of the other things the effects tray does, prima
 
 ```js
   /**
-   * Helper function to allow for macros or other applications
-   * to make a socket request to apply damage.
+   * Helper function to allow for macros or other applications to apply effects to owned 
+   * and unowned targets.
    * @param {string|object|ActiveEffect} effect The effect to apply. 
    *                                            Can handle Uuid, effect data as an object, 
    *                                            or an ActiveEffect proper.
@@ -74,8 +74,7 @@ This helper also allows the use of the other things the effects tray does, prima
 ```js
   /**
    * ... Much documentation cut here...see scripts/api.mjs or better yet, dnd5e...
-   * Helper function to allow for macros or other applications to 
-   * make a socket request to apply damage.
+   * Helper function to allow for macros or other applications to apply damage via socket request.
    * @param {array} damage Array of damage objects; see above.
    * @param {array} opts   Object of options (which may inlude arrays); see above.
    * @param {string} id    Uuid of the target.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ Allows users to use the damage tray for selected tokens that they own, and for t
 - **Scroll on Expand**: Scroll chat to bottom when expanding a tray that is at the bottom (experimental, on by default).
 - **Remove 'Apply Effect to Actor'**: On the time of creation (i.e. drag & drop), remove 'Apply Effect to Actor' from effects on items that have a duration to allow for normal use of the timer (on by default).
 - **Multiple Effects with Concentration**: Allow multiple effects to be applied from spells with concentration (off by default).
+
+## API
+- `effectiv.applyEffect(effect, targets, data = {effectData: null, concentration: null, caster: null})` A helper function to allow users to apply effects.
+- `effectiv.applyDamage(damage=[], opts={}, id)` A helper function to allow users to apply damage.
+See scripts\API.mjs for more information. These helpers are mostly untested and being included before documentation is complete.
 ___
 ###### **Technical Details**
 

--- a/README.md
+++ b/README.md
@@ -29,33 +29,27 @@ This helper also allows the use of the other things the effects tray does, prima
 
 ```js
 /**
- * Helper function to allow for macros or other applications to apply effects to owned 
- * and unowned targets.
- * @param {string|object|ActiveEffect} effect The effect to apply. 
- *                                            Can handle Uuid, effect data as an object, 
- *                                            or an ActiveEffect proper.
- * @param {set|array|string} targets          Targeted tokens. 
- *                                            Handles `game.user.targets`, 
- *                                            or any generic array of token placeables.
- * @param {number|void} effectData            A generic data object, which typically handles
- *                                            the level the originating spell was cast at, 
- *                                            if it originated from a spell, if any. 
- *                                            Use flags like { "flags.dnd5e.spellLevel": 1 }.
- * @param {string|void} concentration         The ID (not Uuid) of the concentration 
- *                                            effect this effect is dependent on, 
- *                                            if any.
- * @param {string|Actor5e|void} caster        The Uuid or Actor5e document of the actor 
- *                                            that cast the spell that requires 
- *                                            concentration, if any.
+ * Helper function to allow for macros or other applications to apply 
+ * effects to owned and unowned targets.
+ * @param {string|object|ActiveEffect5e} effect The effect to apply.
+ * @param {Set<Token5e>|Token5e[]|string[]|string} targets 
+ * Targeted tokens.
+ * @param {object} {}
+ * @param {object} effectData A generic data object, which typically 
+ *                            handles the level the originating spell 
+ *                            was cast at, 
+ *                            if it originated from a spell, if any. 
+ *                            Use flags like { "flags.dnd5e.spellLevel": 1 }.
+ * @param {string} concentration The ID (not Uuid) of the concentration 
+ *                               effect this effect is dependent on, if any.
+ * @param {string|Actor5e} caster The Uuid or Actor5e document of the actor 
+ *                                that cast the spell that requires 
+ *                                concentration, if any.
  */
 async function applyEffect(
   effect, 
   targets, 
-  data = { 
-    effectData: null, 
-    concentration: null, 
-    caster: null 
-  }
+  { effectData: null, concentration: null, caster: null } = {}
 )
 ```
 ```js

--- a/README.md
+++ b/README.md
@@ -28,19 +28,19 @@ Allows users to use the damage tray for selected tokens that they own, and for t
    * @param {string|object|ActiveEffect} effect The effect to apply. 
    *                                            Can handle Uuid, effect data as an object, 
    *                                            or an ActiveEffect proper.
-   * @param {set|array|string} targets Targeted tokens. 
-   *                                   Handles `game.user.targets`, 
-   *                                   or any generic array of token placeables.
-   * @param {number|void} effectData A generic data object, which typically handles
-   *                                 the level the originating spell was cast at, 
-   *                                 if it originated from a spell, if any. 
-   *                                 Use flags like { "flags.dnd5e.spellLevel": 1 }.
-   * @param {string|void} concentration The ID (not Uuid) of the concentration 
-   *                                    effect this effect is dependent on, 
-   *                                    if any.
-   * @param {string|Actor5e|void} caster The Uuid or Actor5e document of the actor 
-   *                                     that cast the spell that requires concentration, 
-   *                                     if any.
+   * @param {set|array|string} targets          Targeted tokens. 
+   *                                            Handles `game.user.targets`, 
+   *                                            or any generic array of token placeables.
+   * @param {number|void} effectData            A generic data object, which typically handles
+   *                                            the level the originating spell was cast at, 
+   *                                            if it originated from a spell, if any. 
+   *                                            Use flags like { "flags.dnd5e.spellLevel": 1 }.
+   * @param {string|void} concentration         The ID (not Uuid) of the concentration 
+   *                                            effect this effect is dependent on, 
+   *                                            if any.
+   * @param {string|Actor5e|void} caster        The Uuid or Actor5e document of the actor 
+   *                                            that cast the spell that requires concentration, 
+   *                                            if any.
    */
   effectiv.applyEffect(effect, 
     targets, 
@@ -59,8 +59,8 @@ Allows users to use the damage tray for selected tokens that they own, and for t
    * Helper function to allow for macros or other applications to 
    * make a socket request to apply damage.
    * @param {array} damage Array of damage objects; see above.
-   * @param {array} opts Object of options (which may inlude arrays); see above.
-   * @param {string} id Uuid of the target.
+   * @param {array} opts   Object of options (which may inlude arrays); see above.
+   * @param {string} id    Uuid of the target.
    */
   effectiv.applyDamage(damage=[], opts={}, id)
 ```

--- a/README.md
+++ b/README.md
@@ -34,15 +34,15 @@ This helper also allows the use of the other things the effects tray does, prima
  * @param {string|object|ActiveEffect5e} effect The effect to apply.
  * @param {Set<Token5e>|Token5e[]|string[]|string} targets 
  * Targeted tokens.
- * @param {object} {}
- * @param {object} effectData A generic data object, which typically 
+ * @param {object} [options]
+ * @param {object} [options.effectData] A generic data object, which typically 
  *                            handles the level the originating spell 
  *                            was cast at, 
  *                            if it originated from a spell, if any. 
  *                            Use flags like { "flags.dnd5e.spellLevel": 1 }.
- * @param {string} concentration The ID (not Uuid) of the concentration 
+ * @param {string} [options.concentration] The ID (not Uuid) of the concentration 
  *                               effect this effect is dependent on, if any.
- * @param {string|Actor5e} caster The Uuid or Actor5e document of the actor 
+ * @param {string|Actor5e} [options.caster] The Uuid or Actor5e document of the actor 
  *                                that cast the spell that requires 
  *                                concentration, if any.
  */

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ Allows users to use the damage tray for selected tokens that they own, and for t
    *                                            effect this effect is dependent on, 
    *                                            if any.
    * @param {string|Actor5e|void} caster        The Uuid or Actor5e document of the actor 
-   *                                            that cast the spell that requires concentration, 
-   *                                            if any.
+   *                                            that cast the spell that requires 
+   *                                            concentration, if any.
    */
   async function applyEffect(
     effect, 

--- a/README.md
+++ b/README.md
@@ -49,8 +49,6 @@ async function applyEffect(
 effectiv.applyEffect(
   effect, 
   targets, 
-  effect, 
-  targets, 
   { effectData: null, concentration: null, caster: null } = {}
 )
 ```

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ This helper also allows the use of the other things the effects tray does, prima
     }
   )
 ```
-`applyDamage`, helper function to allow users to apply damage. This function has been tested not at all and is included as a courtesy. Personally I find the way damage information must be structured to respect resistances, etc is too much of a mess to test this even a single time, but if someone really wants to do this over a socket but didn't write their own socket handler for it...here you go. Full, extensive documentation of the array that must be created is in scripts/api.mjs, copied directly from `dnd5e`, with the exception that socket transmission requires the sets to be arrays.
+`applyDamage`, helper function to allow users to apply damage. This function has been tested not at all and is included as a courtesy. Personally I find the way damage information must be structured to respect resistances, etc is too much of a mess to test this even a single time, but if someone really wants to do this over a socket but didn't write their own socket handler for it...here you go. Full, extensive documentation of the array that must be created is in scripts/api.mjs, copied directly from `dnd5e`, with the exception that socket transmission requires the sets to be arrays. Unlike `applyEffect`, this applies no damage via the requesting client, and so is basically only meant for damaging unowned targets. Users wishing to apply damage to owned targets should simply use the system's `Actor#applyDamage`.
 ```js
   /**
    * ... Much documentation cut here...see scripts/api.mjs or better yet, dnd5e...

--- a/README.md
+++ b/README.md
@@ -20,28 +20,6 @@ Allows users to use the damage tray for selected tokens that they own, and for t
 - **Remove 'Apply Effect to Actor'**: On the time of creation (i.e. drag & drop), remove 'Apply Effect to Actor' from effects on items that have a duration to allow for normal use of the timer (on by default).
 - **Multiple Effects with Concentration**: Allow multiple effects to be applied from spells with concentration (off by default).
 
-## Hooks
-Now includes two hooks, `effectiv.preApplyEffect` and `effectiv.applyEffect`. The former allows the data to be modified and explicitly returning `false` will prevent the effect from being applied. The later passes the same (modified in the case of effectData), information in its final state upon application.
-```js
-/**
- * Hook called before the effect is completed and applied.
- * @param {Actor5e} actor                The actor to create the effect on.
- * @param {ActiveEffect5e} effect        The effect to create.
- * @param {object} effectData            A generic data object that contains spellLevel in a 
- *                                       `dnd5e` scoped flag, and whatever else.
- * @param {ActiveEffect5e} concentration The concentration effect on which `effect` 
- *                                       is dependent, if it requires concentration.
- */
- Hooks.call("effectiv.preApplyEffect", actor, effect, { effectData, concentration });
-
-/**
- * Hook called before the effect is completed and applied.
- * Same as abvove except for effectData
- * @param {object} effectData The packaged effect immediately before application.
- */
- Hooks.callAll("effectiv.applyEffect", actor, effect, { effectData, concentration });
-```
-
 ## API
 Now includes three helper functions exposed in the global scope under `effectiv`, `effectiv.applyEffect`, `effectiv.applyDamage` and `effective.partitionTargets`. These functions *have not been heavily tested* and are included now in the hopes that, if someone wants to use them, they will also test them for issues.
 
@@ -124,8 +102,31 @@ function partitionTargets(targets)
 ```js
   /* in use...*/
   effectiv.partitionTargets(targets)
-```  
-See scripts/api.mjs for more information. These helpers are mostly untested and being included before documentation is complete.
+```
+
+## Hooks
+Now includes two hooks, `effectiv.preApplyEffect` and `effectiv.applyEffect`. The former allows the data to be modified and explicitly returning `false` will prevent the effect from being applied. The later passes the same (modified in the case of effectData), information in its final state upon application. 
+
+These hooks have not been extensively tested.
+```js
+/**
+ * Hook called before the effect is completed and applied.
+ * @param {Actor5e} actor                The actor to create the effect on.
+ * @param {ActiveEffect5e} effect        The effect to create.
+ * @param {object} effectData            A generic data object that contains spellLevel in a 
+ *                                       `dnd5e` scoped flag, and whatever else.
+ * @param {ActiveEffect5e} concentration The concentration effect on which `effect` 
+ *                                       is dependent, if it requires concentration.
+ */
+ Hooks.call("effectiv.preApplyEffect", actor, effect, { effectData, concentration });
+
+/**
+ * Hook called before the effect is completed and applied.
+ * Same as abvove except for effectData
+ * @param {object} effectData The packaged effect immediately before application.
+ */
+ Hooks.callAll("effectiv.applyEffect", actor, effect, { effectData, concentration });
+```
 ___
 ###### **Technical Details**
 

--- a/README.md
+++ b/README.md
@@ -22,11 +22,27 @@ Allows users to use the damage tray for selected tokens that they own, and for t
 
 ## API
 ```js
+  /**
+   * Helper function to allow for macros or other applications to make a socket request to apply damage.
+   * @param {string|object|ActiveEffect} effect The effect to apply. Can handle Uuid, effect data as an object, or an ActiveEffect proper.
+   * @param {set|array|string} targets Targeted tokens. Handles `game.user.targets`, or any generic array of token placeables.
+   * @param {number|void} effectData A generic data object, which typically handleshe level the originating spell was cast at, 
+   *                                 if it originated from a spell, if any. Use flags like { "flags.dnd5e.spellLevel": 1 }.
+   * @param {string|void} concentration The ID (not Uuid) of the concentration effect this effect is dependent on, if any.
+   * @param {string|Actor5e|void} caster The Uuid or Actor5e document of the actor that cast the spell that requires concentration, if any.
+   */
   effectiv.applyEffect(effect, targets, data = {effectData: null, concentration: null, caster: null})
 ```
  A helper function to allow users to apply effects.
 
-```js 
+```js
+  /**
+   * ... Much documentation cut here...see scripts/api.mjs or better yet, dnd5e...
+   * Helper function to allow for macros or other applications make a socket request to apply damage.
+   * @param {array} damage Array of damage objects; see above.
+   * @param {array} opts Object of options (which may inlude arrays); see above.
+   * @param {string} id Uuid of the target.
+   */
   effectiv.applyDamage(damage=[], opts={}, id)
 ```
 A helper function to allow users to apply damage.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ This helper also allows the use of the other things the effects tray does, prima
 ```js
   /**
    * ... Much documentation cut here...see scripts/api.mjs or better yet, dnd5e...
-   * Helper function to allow for macros or other applications to apply damage via socket request.
+   * Helper function to allow for macros or other applications to apply damage 
+   * via socket request.
    * @param {array} damage Array of damage objects; see above.
    * @param {array} opts   Object of options (which may inlude arrays); see above.
    * @param {string} id    Uuid of the target.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ Allows users to use the damage tray for selected tokens that they own, and for t
 - **Multiple Effects with Concentration**: Allow multiple effects to be applied from spells with concentration (off by default).
 
 ## API
+Now includes two helper functions exposed in the global scope under `effectiv`, `effectiv.applyEffect` and `effectiv.applyDamage`. These functions *have not been heavily tested* and are included now in the hopes that, if someone wants to use them, they will also test them for issues.
+
+`applyEffect`, a helper function to allow users to apply effects. It allows users to apply effects via macro (or other module), and can take a variety of types of data when doing so, allowing effect data to be passed as the full ActiveEffect document, an effect Uuid, or an object (note that passing it as an object will not interact with refreshing duration or deleting effects of same origin, as determined by module setting, because creating an effect from an object will have its own unique origin). Similarly, this function allows target data to be passed as an array of Uuids, a single Uuid, an array of Tokens, or a Set, as `game.user.targets`.
+
+This helper also allows the use of the other things the effects tray does, primarily flagging effects with spellLevel, or any other arbitrary flags (via effectData), and making an effect dependent on a concentration effect (so it will be deleted when the concentration effect is). If concentration is used, because it passed as an ID, you must also pass the Uuid or Actor document of the actor the concentration effect is on.
+
 ```js
   /**
    * Helper function to allow for macros or other applications
@@ -64,8 +70,7 @@ Allows users to use the damage tray for selected tokens that they own, and for t
     }
   )
 ```
- A helper function to allow users to apply effects.
-
+`applyDamage`, helper function to allow users to apply damage. This function has been tested not at all and is included as a courtesy. Personally I find the way damage information must be structured to respect resistances, etc is too much of a mess to test this even a single time, but if someone really wants to do this over a socket but didn't write their own socket handler for it...here you go. Full, extensive documentation of the array that must be created is in scripts/api.mjs, copied directly from `dnd5e`, with the exception that socket transmission requires the sets to be arrays.
 ```js
   /**
    * ... Much documentation cut here...see scripts/api.mjs or better yet, dnd5e...
@@ -82,7 +87,6 @@ Allows users to use the damage tray for selected tokens that they own, and for t
   /* in use...*/
   effectiv.applyDamage(damage=[], opts={}, id)
 ```
-A helper function to allow users to apply damage.
 See scripts/api.mjs for more information. These helpers are mostly untested and being included before documentation is complete.
 ___
 ###### **Technical Details**

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Allows users to use the damage tray for selected tokens that they own, and for t
 - **Legacy Targeting for Effects**: Apply effects to target with right click, rather than the target source control (off by default).
 - **Damage Target**: Allow users to damage targets (that they don't own) with the damage tray (off by default).
 - **Delete Instead of Refresh**: Attempting to transfer an effect to an actor that has it already will delete it rather than refreshing its duration (off by default).
-- **Flag Effects with Level**: Adds a flag to active effects applied via the tray on spell messages indicating the level at which the spell was cast, with the scope `ActiveEffect#flags.dnd5e.spellLevel`. This will be provided by the system in 3.2, so it will be on by default (this setting will be removed in 3.2 and enabled for all installs).
 - **Filtering** based on actor type, permissions, and token disposition. This prevents users from seeing and interacting with effects of certain origins, depending on GM preference (no filtering is performed by default).
 - **Use Default Trays**: Adds settings (off by default) to use the default effects and damage trays. Only the features *below* this setting will function if a given tray is in its default mode.
 - **Expand Effects Tray**: The effect tray on chat messages starts in its expanded position when the message is created (on by default).

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ Allows users to use the damage tray for selected tokens that they own, and for t
    *                                            that cast the spell that requires concentration, 
    *                                            if any.
    */
-  effectiv.applyEffect(effect, 
+  effectiv.applyEffect(
+    effect, 
     targets, 
     data = { 
       effectData: null, 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,12 @@ Allows users to use the damage tray for selected tokens that they own, and for t
 - **Multiple Effects with Concentration**: Allow multiple effects to be applied from spells with concentration (off by default).
 
 ## API
-- `effectiv.applyEffect(effect, targets, data = {effectData: null, concentration: null, caster: null})` A helper function to allow users to apply effects.
-- `effectiv.applyDamage(damage=[], opts={}, id)` A helper function to allow users to apply damage.
+- ```js
+  effectiv.applyEffect(effect, targets, data = {effectData: null, concentration: null, caster: null})
+  ``` A helper function to allow users to apply effects.
+- ````js 
+  effectiv.applyDamage(damage=[], opts={}, id)
+  ``` A helper function to allow users to apply damage.
 See scripts/api.mjs for more information. These helpers are mostly untested and being included before documentation is complete.
 ___
 ###### **Technical Details**

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ function partitionTargets(targets)
 ```
 ```js
   /* in use...*/
-  effective.partitionTargets(targets)
+  effectiv.partitionTargets(targets)
 ```  
 See scripts/api.mjs for more information. These helpers are mostly untested and being included before documentation is complete.
 ___

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ Allows users to use the damage tray for selected tokens that they own, and for t
 ```js
   /**
    * ... Much documentation cut here...see scripts/api.mjs or better yet, dnd5e...
-   * Helper function to allow for macros or other applications make a socket request to apply damage.
+   * Helper function to allow for macros or other applications to 
+   * make a socket request to apply damage.
    * @param {array} damage Array of damage objects; see above.
    * @param {array} opts Object of options (which may inlude arrays); see above.
    * @param {string} id Uuid of the target.

--- a/README.md
+++ b/README.md
@@ -23,15 +23,33 @@ Allows users to use the damage tray for selected tokens that they own, and for t
 ## API
 ```js
   /**
-   * Helper function to allow for macros or other applications to make a socket request to apply damage.
-   * @param {string|object|ActiveEffect} effect The effect to apply. Can handle Uuid, effect data as an object, or an ActiveEffect proper.
-   * @param {set|array|string} targets Targeted tokens. Handles `game.user.targets`, or any generic array of token placeables.
-   * @param {number|void} effectData A generic data object, which typically handleshe level the originating spell was cast at, 
-   *                                 if it originated from a spell, if any. Use flags like { "flags.dnd5e.spellLevel": 1 }.
-   * @param {string|void} concentration The ID (not Uuid) of the concentration effect this effect is dependent on, if any.
-   * @param {string|Actor5e|void} caster The Uuid or Actor5e document of the actor that cast the spell that requires concentration, if any.
+   * Helper function to allow for macros or other applications
+   * to make a socket request to apply damage.
+   * @param {string|object|ActiveEffect} effect The effect to apply. 
+   *                                            Can handle Uuid, effect data as an object, 
+   *                                            or an ActiveEffect proper.
+   * @param {set|array|string} targets Targeted tokens. 
+   *                                   Handles `game.user.targets`, 
+   *                                   or any generic array of token placeables.
+   * @param {number|void} effectData A generic data object, which typically handles
+   *                                 the level the originating spell was cast at, 
+   *                                 if it originated from a spell, if any. 
+   *                                 Use flags like { "flags.dnd5e.spellLevel": 1 }.
+   * @param {string|void} concentration The ID (not Uuid) of the concentration 
+   *                                    effect this effect is dependent on, 
+   *                                    if any.
+   * @param {string|Actor5e|void} caster The Uuid or Actor5e document of the actor 
+   *                                     that cast the spell that requires concentration, 
+   *                                     if any.
    */
-  effectiv.applyEffect(effect, targets, data = {effectData: null, concentration: null, caster: null})
+  effectiv.applyEffect(effect, 
+    targets, 
+    data = { 
+      effectData: null, 
+      concentration: null, 
+      caster: null 
+    }
+  )
 ```
  A helper function to allow users to apply effects.
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -15,8 +15,6 @@
   "EFFECTIVETRAY.ExpandDamageSettingHint": "The damage tray on chat messages starts in its expanded position when the message is created.",
   "EFFECTIVETRAY.ExpandEffectSettingName": "Expand Effects Tray",
   "EFFECTIVETRAY.ExpandEffectSettingHint": "The effect tray on chat messages starts in its expanded position when the message is created.",
-  "EFFECTIVETRAY.FlagLevelSettingName": "Flag Effects with Level",
-  "EFFECTIVETRAY.FlagLevelSettingHint": "Adds a flag to active effects applied via the tray on spell messages indicating the level at which the spell was cast.",
   "EFFECTIVETRAY.FilterDispositionSettingName": "Filter by Disposition",
   "EFFECTIVETRAY.FilterDispositionSettingHint": "Hide effects from users if they originate from tokens with the selected (or worse) disposition.",
   "EFFECTIVETRAY.FilterPermissionSettingName": "Filter by Permission",

--- a/module.json
+++ b/module.json
@@ -1,19 +1,26 @@
 {
   "id": "effectivetray",
   "title": "Effective Tray",
-  "version": "1.1.17",
+  "version": "1.1.18",
   "compatibility": {
     "minimum": "11",
     "verified": "11"
   },
-  "esmodules": ["scripts/setup.mjs"],
-  "styles": ["styles/effectivetray.css"],
+  "esmodules": [
+    "scripts/setup.mjs"
+  ],
+  "styles": [
+    "styles/effectivetray.css"
+  ],
   "relationships": {
     "systems": [
       {
         "id": "dnd5e",
         "type": "system",
-        "compatibility": {"minimum": "3.1.0", "maximum": "3.1.9999"}
+        "compatibility": {
+          "minimum": "3.1.0",
+          "maximum": "3.1.9999"
+        }
       }
     ]
   },
@@ -25,11 +32,22 @@
       "flags": {}
     }
   ],
-  "flags": {"hotReload": {"extensions": ["css", "json"], "paths": ["styles/effectivetray.css", "lang"]}},
+  "flags": {
+    "hotReload": {
+      "extensions": [
+        "css",
+        "json"
+      ],
+      "paths": [
+        "styles/effectivetray.css",
+        "lang"
+      ]
+    }
+  },
   "socket": true,
   "url": "https://github.com/etiquettestartshere/effectivetray",
   "manifest": "https://github.com/etiquettestartshere/effectivetray/releases/latest/download/module.json",
-  "download": "https://github.com/etiquettestartshere/effectivetray/releases/latest/download/module.zip",
+  "download": "https://github.com/etiquettestartshere/effectivetray/releases/download/v1.1.17/module.zip",
   "authors": [
     {
       "name": "alakshana",

--- a/module.json
+++ b/module.json
@@ -6,21 +6,14 @@
     "minimum": "11",
     "verified": "11"
   },
-  "esmodules": [
-    "scripts/setup.mjs"
-  ],
-  "styles": [
-    "styles/effectivetray.css"
-  ],
+  "esmodules": ["scripts/setup.mjs"],
+  "styles": ["styles/effectivetray.css"],
   "relationships": {
     "systems": [
       {
         "id": "dnd5e",
         "type": "system",
-        "compatibility": {
-          "minimum": "3.1.0",
-          "maximum": "3.1.9999"
-        }
+        "compatibility": {"minimum": "3.1.0", "maximum": "3.1.9999"}
       }
     ]
   },
@@ -32,22 +25,11 @@
       "flags": {}
     }
   ],
-  "flags": {
-    "hotReload": {
-      "extensions": [
-        "css",
-        "json"
-      ],
-      "paths": [
-        "styles/effectivetray.css",
-        "lang"
-      ]
-    }
-  },
+  "flags": {"hotReload": {"extensions": ["css", "json"], "paths": ["styles/effectivetray.css", "lang"]}},
   "socket": true,
   "url": "https://github.com/etiquettestartshere/effectivetray",
   "manifest": "https://github.com/etiquettestartshere/effectivetray/releases/latest/download/module.json",
-  "download": "https://github.com/etiquettestartshere/effectivetray/releases/download/v1.1.17/module.zip",
+  "download": "https://github.com/etiquettestartshere/effectivetray/releases/latest/download/module.zip",
   "authors": [
     {
       "name": "alakshana",

--- a/scripts/api.mjs
+++ b/scripts/api.mjs
@@ -17,14 +17,15 @@ export class API {
 
   /**
    * Helper function to allow for macros or other applications to apply effects to owned and unowned targets.
-   * @param {string|object|ActiveEffect} effect The effect to apply. Can handle Uuid, effect data as an object, or an ActiveEffect proper.
-   * @param {set|array|string} targets Targeted tokens. Handles `game.user.targets`, or any generic array of token placeables.
-   * @param {number|void} effectData A generic data object, which typically handles the level the originating spell was cast at, 
-   *                                 if it originated from a spell, if any. Use flags like { "flags.dnd5e.spellLevel": 1 }.
-   * @param {string|void} concentration The ID (not Uuid) of the concentration effect this effect is dependent on, if any.
-   * @param {string|Actor5e|void} caster The Uuid or Actor5e document of the actor that cast the spell that requires concentration, if any.
+   * @param {string|object|ActiveEffect5e} effect            The effect to apply.
+   * @param {Set<Token5e>|Token5e[]|string[]|string} targets Targeted tokens.
+   * @param {object} {}
+   * @param {object} effectData                              A generic data object, which typically handles the level the originating spell was cast at, 
+   *                                                         if it originated from a spell, if any. Use flags like { "flags.dnd5e.spellLevel": 1 }.
+   * @param {string} concentration                           The ID (not Uuid) of the concentration effect this effect is dependent on, if any.
+   * @param {string|Actor5e} caster                          The Uuid or Actor5e document of the actor that cast the spell that requires concentration, if any.
    */
-  static async applyEffect(effect, targets, data = {effectData: null, concentration: null, caster: null}) {
+  static async applyEffect(effect, targets, {effectData = null, concentration = null, caster = null} = {}) {
 
     // Effect handling
     let toApply;
@@ -65,14 +66,14 @@ export class API {
 
     // Caster handling
     let spellCaster;
-    if (data?.caster instanceof Actor) spellCaster = data?.caster.uuid;
-    else if (foundry.utils.getType(data?.caster) === "string") spellCaster = data?.caster;
+    if (caster instanceof Actor) spellCaster = caster?.uuid;
+    else if (foundry.utils.getType(caster) === "string") spellCaster = caster;
 
 
     // Apply what effects you can apply yourself
     const actors = new Set();
     for (const token of owned) if (token.actor) actors.add(token.actor);
-    for (const actor of actors) await _applyEffects(actor, effect, {effectData: data?.effectData, concentration: data?.concentration});
+    for (const actor of actors) await _applyEffects(actor, effect, {effectData, concentration});
 
     // Ask the GM client to apply the rest
     if (!game.users.activeGM) return ui.notifications.warn(game.i18n.localize("EFFECTIVETRAY.NOTIFICATION.NoActiveGMEffect"));
@@ -82,8 +83,8 @@ export class API {
       data: { 
         origin: toApply,
         targets: toTarget,
-        effectData: data?.effectData,
-        con: data?.concentration,
+        effectData: effectData,
+        con: concentration,
         caster: spellCaster
       }
     });

--- a/scripts/api.mjs
+++ b/scripts/api.mjs
@@ -18,7 +18,7 @@ export class API {
    * Helper function to allow for macros or other applications to make a socket request to apply damage.
    * @param {string|object|ActiveEffect} effect The effect to apply. Can handle Uuid, effect data as an object, or an ActiveEffect proper.
    * @param {set|array|string} targets Targeted tokens. Handles `game.user.targets`, or any generic array of token placeables.
-   * @param {number|void} effectData A generic data object, which typically handleshe level the originating spell was cast at, 
+   * @param {number|void} effectData A generic data object, which typically handles the level the originating spell was cast at, 
    *                                 if it originated from a spell, if any. Use flags like { "flags.dnd5e.spellLevel": 1 }.
    * @param {string|void} concentration The ID (not Uuid) of the concentration effect this effect is dependent on, if any.
    * @param {string|Actor5e|void} caster The Uuid or Actor5e document of the actor that cast the spell that requires concentration, if any.

--- a/scripts/api.mjs
+++ b/scripts/api.mjs
@@ -146,7 +146,7 @@ export class API {
    * @param {array} opts   Object of options (which may inlude arrays); see above.
    * @param {string} id    Uuid of the target.
    */
-  static async applyDamage(damage=[], opts={}, id) {
+  static async applyDamage(damage = [], opts = {}, id) {
     if (!game.users.activeGM) return ui.notifications.warn(game.i18n.localize("EFFECTIVETRAY.NOTIFICATION.NoActiveGMDamage"));
     await game.socket.emit(socketID, { type: "damage", data: { id, opts, damage } });
   };

--- a/scripts/api.mjs
+++ b/scripts/api.mjs
@@ -19,11 +19,11 @@ export class API {
    * Helper function to allow for macros or other applications to apply effects to owned and unowned targets.
    * @param {string|object|ActiveEffect5e} effect            The effect to apply.
    * @param {Set<Token5e>|Token5e[]|string[]|string} targets Targeted tokens.
-   * @param {object} {}
-   * @param {object} effectData                              A generic data object, which typically handles the level the originating spell was cast at, 
+   * @param {object} [options]
+   * @param {object} [options.effectData]                    A generic data object, which typically handles the level the originating spell was cast at, 
    *                                                         if it originated from a spell, if any. Use flags like { "flags.dnd5e.spellLevel": 1 }.
-   * @param {string} concentration                           The ID (not Uuid) of the concentration effect this effect is dependent on, if any.
-   * @param {string|Actor5e} caster                          The Uuid or Actor5e document of the actor that cast the spell that requires concentration, if any.
+   * @param {string} [options.concentration]                 The ID (not Uuid) of the concentration effect this effect is dependent on, if any.
+   * @param {string|Actor5e} [options.caster]                The Uuid or Actor5e document of the actor that cast the spell that requires concentration, if any.
    */
   static async applyEffect(effect, targets, {effectData = null, concentration = null, caster = null} = {}) {
 

--- a/scripts/api.mjs
+++ b/scripts/api.mjs
@@ -139,7 +139,8 @@ export class API {
    */
 
   /**
-   * Helper function to allow for macros or other applications make a socket request to apply damage.
+   * Helper function to allow for macros or other applications to 
+   * make a socket request to apply damage.
    * @param {array} damage Array of damage objects; see above.
    * @param {array} opts Object of options (which may inlude arrays); see above.
    * @param {string} id Uuid of the target.

--- a/scripts/api.mjs
+++ b/scripts/api.mjs
@@ -1,0 +1,149 @@
+import { MODULE, socketID } from "./const.mjs";
+import { _applyEffects } from "./effective-tray.mjs";
+
+export class API {
+
+  static init() {
+    globalThis.effectiv = {
+      applyEffect: API.applyEffect,
+      applyDamage: API.applyDamage
+    };
+  };
+
+  /* -------------------------------------------- */
+  /*  Effect Application Helper                   */
+  /* -------------------------------------------- */
+
+  /**
+   * Helper function to allow for macros or other applications make a socket request to apply damage.
+   * @param {string|object|ActiveEffect} effect The effect to apply. Can handle UUID, effect data as an object, or an ActiveEffect proper.
+   * @param {set|array|string} targets Targeted tokens. Handles `game.user.targets`, or any generic array of token placeables.
+   * @param {number|void} effectData The level the originating spell was cast at, if it originated from a spell, if any.
+   * @param {string|void} concentration The ID (not UUID) of the concentration effect this effect is dependent on, if any.
+   * @param {string|Actor5e|void} caster The UUID or Actor5e document of the actor that cast the spell that requires concentration, if any.
+   */
+  static async applyEffect(effect, targets, data = {effectData: null, concentration: null, caster: null}) {
+
+    // Effect handling
+    let toApply;
+    const effectType = foundry.utils.getType(effect);
+    if (effect instanceof ActiveEffect) toApply = effect.uuid;
+    else if (effectType === "string" || effectType === "Object") toApply = effect;
+
+    // Target handling
+    let toTarget;
+    let owned;
+    if (targets instanceof Set) {
+      owned = Array.from(targets).filter(t => t.document.isOwner);
+      toTarget = Array.from(targets).reduce((acc, t) => {
+        if (!t.document?.isOwner) acc.push(t.document?.uuid);
+        return acc;
+      }, []);
+    }  
+    else if (foundry.utils.getType(targets) === "string") {
+      const t = await fromUuid(targets);
+      t.document.isOwner? owned = t : toTarget = Array.from(t);
+    }  
+    else if (targets.at(0) instanceof Token) {
+      owned = targets.filter(t => t.document.isOwner);
+      toTarget = targets.reduce((acc, t) => {
+        if (!t.document?.isOwner) acc.push(t.document?.uuid);
+        return acc;
+      }, []);
+      
+    }  
+    else {
+      toTarget = [];
+      owned = [];
+      for (const target of targets) {
+        const t = await fromUuid(target);
+        if (t.isOwned) owned.push(t);
+        else toTarget.push(t);
+      };
+    }  
+
+    // Caster handling
+    let spellCaster;
+    if (data?.caster instanceof Actor) spellCaster = data?.caster.uuid;
+    else if (foundry.utils.getType(data?.caster) === "string") spellCaster = data?.caster;
+
+    const actors = new Set();
+    for (const token of owned) if (token.actor) actors.add(token.actor);
+    for (const actor of actors) await _applyEffects(actor, effect, {effectData: data?.effectData, concentration: data?.concentration});
+
+    if (!game.users.activeGM) return ui.notifications.warn(game.i18n.localize("EFFECTIVETRAY.NOTIFICATION.NoActiveGMEffect"));
+
+    await game.socket.emit(socketID, { 
+      type: "effect",
+      data: { 
+        origin: toApply,
+        targets: toTarget,
+        effectData: data?.effectData,
+        con: data?.concentration,
+        caster: spellCaster
+      }
+    });
+  };
+
+  /* -------------------------------------------- */
+  /*  Damage Application Helper                   */
+  /*                                              */
+  /*    below is documentation for the system's   */
+  /*    applyDamage() function which this calls,  */
+  /*    with the change that all Sets are Arrays  */
+  /* -------------------------------------------- */
+
+  /**
+   * Description of a source of damage. 
+   *
+   * @typedef {object} DamageDescription
+   * @property {number} value            Amount of damage.
+   * @property {string} type             Type of damage.
+   * @property {Array<string>} properties  Physical properties that affect damage application.
+   * @property {object} [active]
+   * @property {number} [active.multiplier]      Final calculated multiplier.
+   * @property {boolean} [active.modifications]  Did modification affect this description?
+   * @property {boolean} [active.resistance]     Did resistance affect this description?
+   * @property {boolean} [active.vulnerability]  Did vulnerability affect this description?
+   * @property {boolean} [active.immunity]       Did immunity affect this description?
+   */
+
+  /**
+   * Options for damage application.
+   *
+   * @typedef {object} DamageApplicationOptions
+   * @property {boolean|Array<string>} [downgrade]  Should this actor's resistances and immunities be downgraded by one
+   *                                              step? A Array of damage types to be downgraded or `true` to downgrade
+   *                                              all damage types.
+   * @property {number} [multiplier=1]         Amount by which to multiply all damage.
+   * @property {object|boolean} [ignore]       Array to `true` to ignore all damage modifiers. If Array to an object, then
+   *                                           values can either be `true` to indicate that the all modifications of
+   *                                           that type should be ignored, or a Array of specific damage types for which
+   *                                           it should be ignored.
+   * @property {boolean|Array<string>} [ignore.immunity]       Should this actor's damage immunity be ignored?
+   * @property {boolean|Array<string>} [ignore.resistance]     Should this actor's damage resistance be ignored?
+   * @property {boolean|Array<string>} [ignore.vulnerability]  Should this actor's damage vulnerability be ignored?
+   * @property {boolean|Array<string>} [ignore.modification]   Should this actor's damage modification be ignored?
+   * @property {boolean} [invertHealing=true]  Automatically invert healing types to it heals, rather than damages.
+   * @property {"damage"|"healing"} [only]     Apply only damage or healing parts. Untyped rolls will always be applied.
+   */
+
+  /**
+   * Apply a certain amount of damage or healing to the health pool for Actor
+   * @param {DamageDescription[]|number} damages     Damages to apply.
+   * @param {DamageApplicationOptions} [options={}]  Damage application options.
+   * @returns {Promise<Actor5e>}                     A Promise which resolves once the damage has been applied.
+   */
+
+  /**
+   * Helper function to allow for macros or other applications make a socket request to apply damage.
+   * @param {array} damage Array of damage objects; see above.
+   * @param {array} opts Object of options (which may inlude arrays); see above.
+   * @param {string} id Uuid of the target.
+   */
+  static async applyDamage(damage=[], opts={}, id) {
+    if (!game.users.activeGM) return ui.notifications.warn(game.i18n.localize("EFFECTIVETRAY.NOTIFICATION.NoActiveGMDamage"));
+    await game.socket.emit(socketID, { type: "damage", data: { id, opts, damage } });
+  };
+
+};

--- a/scripts/api.mjs
+++ b/scripts/api.mjs
@@ -143,8 +143,8 @@ export class API {
   /**
    * Helper function to allow for macros or other applications to apply damage via socket request.
    * @param {array} damage Array of damage objects; see above.
-   * @param {array} opts Object of options (which may inlude arrays); see above.
-   * @param {string} id Uuid of the target.
+   * @param {array} opts   Object of options (which may inlude arrays); see above.
+   * @param {string} id    Uuid of the target.
    */
   static async applyDamage(damage=[], opts={}, id) {
     if (!game.users.activeGM) return ui.notifications.warn(game.i18n.localize("EFFECTIVETRAY.NOTIFICATION.NoActiveGMDamage"));

--- a/scripts/api.mjs
+++ b/scripts/api.mjs
@@ -1,5 +1,5 @@
 import { MODULE, socketID } from "./const.mjs";
-import { _applyEffects } from "./effective-tray.mjs";
+import { _applyEffects, partitionTargets} from "./effective-tray.mjs";
 
 export class API {
 
@@ -42,23 +42,14 @@ export class API {
     let owned;
     let toTarget;
     if (targets instanceof Set) {
-      [owned, toTarget] = Array.from(targets).reduce((acc, t) => {
-        if (t.isOwner) acc[0].push(t);
-        else acc[1].push(t.document.uuid);
-        return acc;
-      }, [[], []]);
+      [owned, toTarget] = partitionTargets(Array.from(targets));
     }
     else if (foundry.utils.getType(targets) === "string") {
       const t = await fromUuid(targets);
       t.document.isOwner ? owned = t : toTarget = Array.from(t);
     }
     else if (targets.at(0) instanceof Token) {
-      [owned, toTarget] = targets.reduce((acc, t) => {
-        if (t.isOwner) acc[0].push(t);
-        else acc[1].push(t.document.uuid);
-        return acc;
-      }, [[], []]);
-
+      partitionTargets(targets);
     } 
     else {
       owned = [];

--- a/scripts/api.mjs
+++ b/scripts/api.mjs
@@ -6,7 +6,8 @@ export class API {
   static init() {
     globalThis.effectiv = {
       applyEffect: API.applyEffect,
-      applyDamage: API.applyDamage
+      applyDamage: API.applyDamage,
+      partitionTargets: partitionTargets
     };
   };
 
@@ -15,7 +16,7 @@ export class API {
   /* -------------------------------------------- */
 
   /**
-   * Helper function to allow for macros or other applications to make a socket request to apply damage.
+   * Helper function to allow for macros or other applications to apply effects to owned and unowned targets.
    * @param {string|object|ActiveEffect} effect The effect to apply. Can handle Uuid, effect data as an object, or an ActiveEffect proper.
    * @param {set|array|string} targets Targeted tokens. Handles `game.user.targets`, or any generic array of token placeables.
    * @param {number|void} effectData A generic data object, which typically handles the level the originating spell was cast at, 
@@ -139,8 +140,7 @@ export class API {
    */
 
   /**
-   * Helper function to allow for macros or other applications to 
-   * make a socket request to apply damage.
+   * Helper function to allow for macros or other applications to apply damage via socket request.
    * @param {array} damage Array of damage objects; see above.
    * @param {array} opts Object of options (which may inlude arrays); see above.
    * @param {string} id Uuid of the target.

--- a/scripts/effective-tray.mjs
+++ b/scripts/effective-tray.mjs
@@ -416,11 +416,7 @@ async function _effectApplicationHandler(tray, effect, {effectData, concentratio
       };
     };
   } else {
-    const [owned, targets] = Array.from(game.user.targets).reduce((acc, t) => {
-      if (t.isOwner) acc[0].push(t);
-      else acc[1].push(t.document.uuid);
-      return acc;
-    }, [[], []]);
+    const [owned, targets] = partitionTargets(game.user.targets);
     const actors = new Set();
     for (const token of owned) if (token.actor) actors.add(token.actor);
     for (const actor of actors) {
@@ -506,4 +502,17 @@ async function _scroll(mid) {
     await new Promise(r => setTimeout(r, 256));
     window.ui.sidebar.popouts.chat.scrollBottom();
   };
+};
+
+/**
+ * Sort tokens into owned and unowned categories.
+ * @param {set|array} targets The set or array of tokens to be sorted.
+ */
+export function partitionTargets(targets) {
+  const result = targets.reduce((acc, t) => {
+    if (t.isOwner) acc[0].push(t);
+    else acc[1].push(t.document.uuid);
+    return acc;
+  }, [[], []]);
+  return result;
 };

--- a/scripts/effective-tray.mjs
+++ b/scripts/effective-tray.mjs
@@ -81,7 +81,7 @@ export class effectiveTray {
         "EFFECTIVETRAY.TOOLTIP.EffectsApplyTokensLegacy" :
         "EFFECTIVETRAY.TOOLTIP.EffectsApplyTokens"
     ) : "DND5E.EffectsApplyTokens";
-    const effectData = { "flags.dnd5e.spellLevel": message.flags?.dnd5e?.use?.spellLevel};
+    const effectData = { "flags.dnd5e.spellLevel": message.flags?.dnd5e?.use?.spellLevel };
     for (const effect of effects) {
       const concentration = actor.effects.get(message.getFlag("dnd5e", "use.concentrationId"));
       const caster = actor.uuid;

--- a/scripts/effective-tray.mjs
+++ b/scripts/effective-tray.mjs
@@ -416,7 +416,11 @@ async function _effectApplicationHandler(tray, effect, {effectData, concentratio
       };
     };
   } else {
-    const owned = Array.from(game.user.targets).filter(t => t.document?.isOwner);
+    const [owned, targets] = Array.from(game.user.targets).reduce((acc, t) => {
+      if (t.isOwner) acc[0].push(t);
+      else acc[1].push(t.document.uuid);
+      return acc;
+    }, [[], []]);
     const actors = new Set();
     for (const token of owned) if (token.actor) actors.add(token.actor);
     for (const actor of actors) {
@@ -426,12 +430,8 @@ async function _effectApplicationHandler(tray, effect, {effectData, concentratio
         tray.classList.remove("et-uncollapsed");
       };
     };
-    if (!game.users.activeGM) return ui.notifications.warn(game.i18n.localize("EFFECTIVETRAY.NOTIFICATION.NoActiveGMEffect"));
-    const targets = Array.from(game.user.targets).reduce((acc, t) => {
-      if (!t.document?.isOwner) acc.push(t.document?.uuid);
-      return acc;
-    }, []);
     if (!targets.length) return;
+    if (!game.users.activeGM) return ui.notifications.warn(game.i18n.localize("EFFECTIVETRAY.NOTIFICATION.NoActiveGMEffect"));
     const origin = effect.uuid;
     const con = concentration?.id;
     await game.socket.emit(socketID, { type: "effect", data: { origin, targets, effectData, con, caster } });

--- a/scripts/effective-tray.mjs
+++ b/scripts/effective-tray.mjs
@@ -82,7 +82,7 @@ export class effectiveTray {
         "EFFECTIVETRAY.TOOLTIP.EffectsApplyTokens"
     ) : "DND5E.EffectsApplyTokens";
     let spellLevel;
-    if ( message.flags?.dnd5e?.use?.spellLevel ) spellLevel = 0;
+    if (!message.flags?.dnd5e?.use?.spellLevel) spellLevel = 0;
     else spellLevel = parseInt(message.flags?.dnd5e?.use?.spellLevel) || null;
     const effectData = { "flags.dnd5e.spellLevel": spellLevel };
     const concentration = actor.effects.get(message.getFlag("dnd5e", "use.concentrationId"));

--- a/scripts/effective-tray.mjs
+++ b/scripts/effective-tray.mjs
@@ -45,7 +45,7 @@ export class effectiveTray {
   /**
    * Make the effects tray effective
    * @param {ChatMessage5e} message The message on which the tray resides.
-   * @param {HTMLElement} html HTML contents of the message.
+   * @param {HTMLElement} html      HTML contents of the message.
    * Methods lacking documentation below share these parameters.
    */
   static async _effectTray(message, html) {
@@ -246,7 +246,7 @@ export class effectiveDamage {
   /**
    * Make the damage tray effective
    * @param {ChatMessage5e} message The message on which the tray resides.
-   * @param {HTMLElement} html HTML contents of the message.
+   * @param {HTMLElement} html      HTML contents of the message.
    * Methods lacking documentation below share these parameters.
    */
   static _damageTray(message, html) {
@@ -397,11 +397,11 @@ async function _damageSocket(request) {
 
 /**
  * Handle applying effects to targets: handle it if you can handle it, else make a request via socket
- * @param {HTMLElement} tray HTML element that composes the collapsible tray.
- * @param {ActiveEffect5e} effect The effect to create.
- * @param {number} lvl The spellLevel of the spell the effect is on, if it is on a spell.
+ * @param {HTMLElement} tray             HTML element that composes the collapsible tray.
+ * @param {ActiveEffect5e} effect        The effect to create.
+ * @param {object} effectData            A generic data object that contains spellLevel in a `dnd5e` scoped flag, and whatever else.
  * @param {ActiveEffect5e} concentration The concentration effect on which `effect` is dependent, if it requires concentration.
- * @param {string} caster The Uuid of the actor which originally cast the spell requiring concentration.
+ * @param {string} caster                The Uuid of the actor which originally cast the spell requiring concentration.
  */
 async function _effectApplicationHandler(tray, effect, { effectData, concentration, caster }) {
   if (!game.user.targets.size) return ui.notifications.info(game.i18n.localize("EFFECTIVETRAY.NOTIFICATION.NoTarget"));
@@ -430,9 +430,9 @@ async function _effectApplicationHandler(tray, effect, { effectData, concentrati
 
 /**
  * Apply effect, or refresh its duration (and level) if it exists
- * @param {Actor5e} actor The actor to create the effect on.
- * @param {ActiveEffect5e} effect The effect to create.
- * @param {object} effectData A generic data object that contains spellLevel in a `dnd5e` scoped flag, and whatever else.
+ * @param {Actor5e} actor                The actor to create the effect on.
+ * @param {ActiveEffect5e} effect        The effect to create.
+ * @param {object} effectData            A generic data object that contains spellLevel in a `dnd5e` scoped flag, and whatever else.
  * @param {ActiveEffect5e} concentration The concentration effect on which `effect` is dependent, if it requires concentration.
  */
 export async function _applyEffects(actor, effect, { effectData, concentration }) {
@@ -478,9 +478,9 @@ export async function _applyEffects(actor, effect, { effectData, concentration }
 
 /**
  * Apply damage
- * @param {string} id The id of the actor to apply damage to.
+ * @param {string} id      The id of the actor to apply damage to.
  * @param {object} options The options provided by the tray, primarily the multiplier.
- * @param {array} damage An array of objects with the damage type and value that also contain Sets with damage properties.
+ * @param {array} damage   An array of objects with the damage type and value that also contain Sets with damage properties.
  */
 async function _applyTargetDamage(id, options, damage) {
   const actor = fromUuidSync(id);
@@ -505,8 +505,8 @@ async function _scroll(mid) {
 
 /**
  * Sort tokens into owned and unowned categories.
- * @param {set|array} targets The set or array of tokens to be sorted.
- * @returns {Array} An Array of length two whose elements are the partitioned pieces of the original
+ * @param {Set|array} targets The set or array of tokens to be sorted.
+ * @returns {array}           An Array of length two whose elements are the partitioned pieces of the original
  */
 export function partitionTargets(targets) {
   const result = targets.reduce((acc, t) => {

--- a/scripts/effective-tray.mjs
+++ b/scripts/effective-tray.mjs
@@ -81,10 +81,13 @@ export class effectiveTray {
         "EFFECTIVETRAY.TOOLTIP.EffectsApplyTokensLegacy" :
         "EFFECTIVETRAY.TOOLTIP.EffectsApplyTokens"
     ) : "DND5E.EffectsApplyTokens";
-    const effectData = { "flags.dnd5e.spellLevel": message.flags?.dnd5e?.use?.spellLevel };
+    let spellLevel;
+    if ( message.flags?.dnd5e?.use?.spellLevel ) spellLevel = 0;
+    else spellLevel = parseInt(message.flags?.dnd5e?.use?.spellLevel) || null;
+    const effectData = { "flags.dnd5e.spellLevel": spellLevel };
+    const concentration = actor.effects.get(message.getFlag("dnd5e", "use.concentrationId"));
+    const caster = actor.uuid;
     for (const effect of effects) {
-      const concentration = actor.effects.get(message.getFlag("dnd5e", "use.concentrationId"));
-      const caster = actor.uuid;
       const label = effect.duration.duration ? effect.duration.label : "";
       const contents = `
         <li class="effect" data-uuid=${uuid}.ActiveEffect.${effect.id} data-transferred=${effect.transfer}>

--- a/scripts/effective-tray.mjs
+++ b/scripts/effective-tray.mjs
@@ -101,29 +101,29 @@ export class effectiveTray {
       tray.querySelector('ul.effects.unlist').insertAdjacentHTML("beforeend", contents);
 
       // Handle click events
-      tray.querySelector(`li[data-uuid="${uuid}.ActiveEffect.${effect.id}"]`)?.querySelector("button").addEventListener('click', async() => {
+      tray.querySelector(`li[data-uuid="${uuid}.ActiveEffect.${effect.id}"]`)?.querySelector("button").addEventListener('click', async () => {
         const mode = tray.querySelector(`[aria-pressed="true"]`)?.dataset?.mode;
         if (!mode || mode === "selected") {
           const actors = new Set();
           for (const token of canvas.tokens.controlled) if (token.actor) actors.add(token.actor);
           for (const actor of actors) {
-            await _applyEffects(actor, effect, {effectData, concentration});
+            await _applyEffects(actor, effect, { effectData, concentration });
             if (!game.settings.get(MODULE, "dontCloseOnPress")) {
               tray.classList.add("collapsed");
               tray.classList.remove("et-uncollapsed");
-            };  
+            };
           };
         } else {
-          _effectApplicationHandler(tray, effect, {effectData, concentration, caster});
+          _effectApplicationHandler(tray, effect, { effectData, concentration, caster });
         };
       });
 
       // Handle legacy targeting mode
       if (game.settings.get(MODULE, "allowTarget") && game.settings.get(MODULE, "contextTarget")) {
-        tray.querySelector(`li[data-uuid="${uuid}.ActiveEffect.${effect.id}"]`)?.querySelector("button").addEventListener('contextmenu', async function(event) {
+        tray.querySelector(`li[data-uuid="${uuid}.ActiveEffect.${effect.id}"]`)?.querySelector("button").addEventListener('contextmenu', async function (event) {
           event.stopPropagation();
           event.preventDefault();
-          _effectApplicationHandler(tray, effect, {effectData, concentration, caster});
+          _effectApplicationHandler(tray, effect, { effectData, concentration, caster });
         });
       };
     };
@@ -141,7 +141,7 @@ export class effectiveTray {
       event.preventDefault();
       if (html.querySelector(".et-uncollapsed")) {
         tray.classList.remove("et-uncollapsed");
-      };  
+      };
       if (!html.querySelector(".effects-tray.collapsed")) {
         tray.classList.add("collapsed");
       } else if (html.querySelector(".effects-tray.collapsed")) tray.classList.remove("collapsed");
@@ -177,7 +177,7 @@ export class effectiveTray {
     if (game.settings.get(MODULE, "dontCloseOnPress")) {
       const buttons = tray.querySelectorAll("button");
       for (const button of buttons) {
-        button.addEventListener('click', async() => {
+        button.addEventListener('click', async () => {
           if (!tray.querySelector(".et-uncollapsed")) {
             await tray.classList.add("et-uncollapsed");
             await new Promise(r => setTimeout(r, 108));
@@ -367,7 +367,7 @@ async function _effectSocket(request) {
     if (target) actors.add(targetActor);
   };
   for (const actor of actors) {
-    await _applyEffects(actor, effect, {effectData, concentration});
+    await _applyEffects(actor, effect, { effectData, concentration });
   };
 };
 
@@ -403,13 +403,13 @@ async function _damageSocket(request) {
  * @param {ActiveEffect5e} concentration The concentration effect on which `effect` is dependent, if it requires concentration.
  * @param {string} caster The Uuid of the actor which originally cast the spell requiring concentration.
  */
-async function _effectApplicationHandler(tray, effect, {effectData, concentration, caster}) {
+async function _effectApplicationHandler(tray, effect, { effectData, concentration, caster }) {
   if (!game.user.targets.size) return ui.notifications.info(game.i18n.localize("EFFECTIVETRAY.NOTIFICATION.NoTarget"));
   if (game.user.isGM) {
     const actors = new Set();
     for (const token of game.user.targets) if (token.actor) actors.add(token.actor);
     for (const actor of actors) {
-      await _applyEffects(actor, effect, {effectData, concentration});
+      await _applyEffects(actor, effect, { effectData, concentration });
       if (!game.settings.get(MODULE, "dontCloseOnPress")) {
         tray.classList.add("collapsed");
         tray.classList.remove("et-uncollapsed");
@@ -420,7 +420,7 @@ async function _effectApplicationHandler(tray, effect, {effectData, concentratio
     const actors = new Set();
     for (const token of owned) if (token.actor) actors.add(token.actor);
     for (const actor of actors) {
-      await _applyEffects(actor, effect, {effectData, concentration});
+      await _applyEffects(actor, effect, { effectData, concentration });
       if (!game.settings.get(MODULE, "dontCloseOnPress")) {
         tray.classList.add("collapsed");
         tray.classList.remove("et-uncollapsed");
@@ -445,7 +445,7 @@ async function _effectApplicationHandler(tray, effect, {effectData, concentratio
  * @param {number} lvl The spellLevel of the spell the effect is on, if it is on a spell.
  * @param {ActiveEffect5e} concentration The concentration effect on which `effect` is dependent, if it requires concentration.
  */
-export async function _applyEffects(actor, effect, {effectData, concentration}) {
+export async function _applyEffects(actor, effect, { effectData, concentration }) {
 
   // Enable an existing effect on the target if it originated from this effect
   const origin = game.settings.get(MODULE, "multipleConcentrationEffects") ? effect : concentration ?? effect;
@@ -459,7 +459,7 @@ export async function _applyEffects(actor, effect, {effectData, concentration}) 
         disabled: false
       }, effectData));
 
-    // Or delete it instead
+      // Or delete it instead
     } else existingEffect.delete();
   } else {
 

--- a/scripts/effective-tray.mjs
+++ b/scripts/effective-tray.mjs
@@ -510,6 +510,7 @@ async function _scroll(mid) {
 /**
  * Sort tokens into owned and unowned categories.
  * @param {set|array} targets The set or array of tokens to be sorted.
+ * @returns {Array} An Array of length two whose elements are the partitioned pieces of the original
  */
 export function partitionTargets(targets) {
   const result = targets.reduce((acc, t) => {

--- a/scripts/settings.mjs
+++ b/scripts/settings.mjs
@@ -51,17 +51,6 @@ export class moduleSettings {
       onChange: false
     });
 
-    game.settings.register(MODULE, "flagLevel", {
-      name: "EFFECTIVETRAY.FlagLevelSettingName",
-      hint: "EFFECTIVETRAY.FlagLevelSettingHint",
-      scope: "world",
-      config: true,
-      type: Boolean,
-      default: true,
-      requiresReload: false,
-      onChange: false
-    });
-
     game.settings.register(MODULE, "ignoreNPC", {
       name: "EFFECTIVETRAY.IgnoreNPCSettingName",
       hint: "EFFECTIVETRAY.IgnoreNPCSettingHint",

--- a/scripts/settings.mjs
+++ b/scripts/settings.mjs
@@ -47,7 +47,7 @@ export class moduleSettings {
       config: true,
       type: Boolean,
       default: false,
-      requiresReload: true,
+      requiresReload: false,
       onChange: false
     });
 

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -1,5 +1,6 @@
 import { moduleSettings } from "./settings.mjs";
 import { effectiveSocket, effectiveTray, effectiveDamage } from "./effective-tray.mjs";
+import { API } from "./api.mjs";
 import EffectiveDAE from "./damage-application.mjs";
 
 window.customElements.define("effective-damage-application", EffectiveDAE);
@@ -8,5 +9,6 @@ Hooks.once("init", effectiveSocket.init);
 Hooks.once("init", moduleSettings.init);
 Hooks.once("init", effectiveTray.init);
 Hooks.once("init", effectiveDamage.init);
+Hooks.once("init", API.init);
 
 export { EffectiveDAE };


### PR DESCRIPTION
closes #74 if i finish the doc

adds helper functions (untested memes), switches (more or less) to the system's method of flagging spellLevel, and now users who own tokens can apply effects directly to them via targeting and will only request the GM client do so if they do not own them.