### PR TITLE
Fix damage aggregation using non damage roll (RSR compatibility)

### DIFF
--- a/scripts/effective-tray.mjs
+++ b/scripts/effective-tray.mjs
@@ -113,11 +113,18 @@ export class EffectiveTray {
         if ((!message.isAuthor || message.blind) && message.whisper.length && !message.whisper.includes(game.user.id)) return;
         const damageApplication = document.createElement("effective-damage-application");
         damageApplication.classList.add("dnd5e2");
-        damageApplication.damages = dnd5e.dice.aggregateDamageRolls(message.rolls, { respectProperties: true }).map(roll => ({
-          value: roll.total,
-          type: roll.options.type,
-          properties: new Set(roll.options.properties ?? [])
-        }));
+        damageApplication.damages = dnd5e.dice
+          .aggregateDamageRolls(
+            message.rolls.filter(
+              (roll) => roll.constructor.name == "DamageRoll"
+            ),
+            { respectProperties: true }
+          )
+          .map((roll) => ({
+            value: roll.total,
+            type: roll.options.type,
+            properties: new Set(roll.options.properties ?? []),
+          }));
         html.querySelector(".message-content").appendChild(damageApplication);
       };
     };


### PR DESCRIPTION
A small patch to improve compatibility with Ready Set Roll. When damage is aggregated, all rolls in the message are taken into account, but in the case of RSR, this means that the attack roll is also taken into account.